### PR TITLE
Update Chinese(Tradition) localization

### DIFF
--- a/Pock/Localisations/zh-Hant.lproj/Localizable.strings
+++ b/Pock/Localisations/zh-Hant.lproj/Localizable.strings
@@ -23,6 +23,8 @@
 "30 seconds" = "30 秒";
 "1 minute" = "1 分鐘";
 "3 minutes" = "3 分鐘";
+"More Than 1 Window" = "多於一個視窗時";
+"Always" = "永遠";
 "Pock Options" = "Pock 選項";
 "Preferences…" = "偏好設定…";
 "Customize…" = "自訂觸控列…";


### PR DESCRIPTION
Updated some strings in the new version.
I cannot build the app on my computer, so it may need some verification before merging. Sorry for the inconvenience.
The string `Open app expose:` seems not added to localized string. I don't have experience in macOS app development, so I don't really know how to add it.