### PR TITLE
Automatically scroll to the frontmost app when switching apps

### DIFF
--- a/Pock/Widgets/Dock/DockWidget.swift
+++ b/Pock/Widgets/Dock/DockWidget.swift
@@ -189,6 +189,9 @@ extension DockWidget: DockDelegate {
                 view.set(isRunning:   item?.isRunning   ?? false)
                 view.set(isFrontmost: item?.isFrontmost ?? false)
                 view.set(isLaunching: item?.isLaunching ?? false)
+                if let i = item, i.isFrontmost && !i.isPersistentItem {
+                    s.dockScrubber?.animator().scrollItem(at: i.index, to: .none)
+                }
             })
         }
     }


### PR DESCRIPTION
This makes sure that the current app is always visible unless the user manually scrolls away.