### PR TITLE
Persistent brightness changes

### DIFF
--- a/Pock.xcodeproj/project.pbxproj
+++ b/Pock.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		009B0E12E317757741CE38C8 /* Pods_Pock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 863BE70CFBAC31BDBF35B1FD /* Pods_Pock.framework */; };
+		127C73A423EEAC7C00D6DDF9 /* CoreDisplay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 127C73A323EEAC7C00D6DDF9 /* CoreDisplay.framework */; };
 		34064337227E224700981372 /* DockFolderController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34064336227E224700981372 /* DockFolderController.swift */; };
 		3406433E227ED8BC00981372 /* DockFolderItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3406433D227ED8BC00981372 /* DockFolderItemView.swift */; };
 		34064343227EDC2200981372 /* DockFolderRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34064342227EDC2200981372 /* DockFolderRepository.swift */; };
@@ -88,6 +89,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		127C73A223EEAADE00D6DDF9 /* CoreDisplayPrivateAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreDisplayPrivateAPI.h; sourceTree = "<group>"; };
+		127C73A323EEAC7C00D6DDF9 /* CoreDisplay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreDisplay.framework; path = ../../../../../System/Library/Frameworks/CoreDisplay.framework; sourceTree = "<group>"; };
 		34064336227E224700981372 /* DockFolderController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockFolderController.swift; sourceTree = "<group>"; };
 		3406433D227ED8BC00981372 /* DockFolderItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockFolderItemView.swift; sourceTree = "<group>"; };
 		34064342227EDC2200981372 /* DockFolderRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockFolderRepository.swift; sourceTree = "<group>"; };
@@ -222,6 +225,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				127C73A423EEAC7C00D6DDF9 /* CoreDisplay.framework in Frameworks */,
 				34F27F2923428174001EBB6B /* login.framework in Frameworks */,
 				349431ED22197485008622B1 /* MediaRemote.framework in Frameworks */,
 				34BC3ECC2210B2EC00C1DD3C /* DFRFoundation.framework in Frameworks */,
@@ -428,6 +432,7 @@
 			isa = PBXGroup;
 			children = (
 				342D83B02278D5CF000D79DA /* DKBrightness.swift */,
+				127C73A223EEAADE00D6DDF9 /* CoreDisplayPrivateAPI.h */,
 			);
 			path = DKBrightness;
 			sourceTree = "<group>";
@@ -626,6 +631,7 @@
 		4ED8D081458713BE440562D3 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				127C73A323EEAC7C00D6DDF9 /* CoreDisplay.framework */,
 				34F27F2523428108001EBB6B /* LaunchAtLogin.framework */,
 				347F335D22D0D5F600FA9805 /* login.framework */,
 				3494320B222179D7008622B1 /* BatteryUIKit.framework */,

--- a/Pock/Private/DKBrightness/CoreDisplayPrivateAPI.h
+++ b/Pock/Private/DKBrightness/CoreDisplayPrivateAPI.h
@@ -1,0 +1,14 @@
+//
+//  CoreDisplayPrivateAPI.h
+//  Pock
+//
+//  Created by David Gstir on 08.02.20.
+//  Copyright © 2020 David Gstir. All rights reserved.
+//
+
+NS_ASSUME_NONNULL_BEGIN
+
+CF_EXPORT void CoreDisplay_Display_SetUserBrightness(int CGDirectDisplayID, double level);
+CF_EXPORT double CoreDisplay_Display_GetUserBrightness(int CGDirectDisplayID);
+
+NS_ASSUME_NONNULL_END

--- a/Pock/Private/DKBrightness/DKBrightness.swift
+++ b/Pock/Private/DKBrightness/DKBrightness.swift
@@ -21,26 +21,34 @@ class DKBrightness {
     }
     
     class func setBrightnessLevel(level: Float) {
-        var iterator: io_iterator_t = 0
-        if IOServiceGetMatchingServices(kIOMasterPortDefault, IOServiceMatching("IODisplayConnect"), &iterator) == kIOReturnSuccess {
-            var service: io_object_t = 1
-            while service != 0 {
-                service = IOIteratorNext(iterator)
-                IODisplaySetFloatParameter(service, 0, kIODisplayBrightnessKey as CFString, level)
-                IOObjectRelease(service)
+        if #available(OSX 10.13, *) {
+            CoreDisplay_Display_SetUserBrightness(0, Double(level))
+        } else {
+            var iterator: io_iterator_t = 0
+            if IOServiceGetMatchingServices(kIOMasterPortDefault, IOServiceMatching("IODisplayConnect"), &iterator) == kIOReturnSuccess {
+                var service: io_object_t = 1
+                while service != 0 {
+                    service = IOIteratorNext(iterator)
+                    IODisplaySetFloatParameter(service, 0, kIODisplayBrightnessKey as CFString, level)
+                    IOObjectRelease(service)
+                }
             }
         }
     }
     
     class func getBrightnessLevel() -> Float {
         var brightness: Float = 0.0
-        var iterator: io_iterator_t = 0
-        if IOServiceGetMatchingServices(kIOMasterPortDefault, IOServiceMatching("IODisplayConnect"), &iterator) == kIOReturnSuccess {
-            var service: io_object_t = 1
-            while service != 0 {
-                service = IOIteratorNext(iterator)
-                IODisplayGetFloatParameter(service, 0, kIODisplayBrightnessKey as CFString, &brightness)
-                IOObjectRelease(service)
+        if #available(OSX 10.13, *) {
+                brightness = Float32(CoreDisplay_Display_GetUserBrightness(0))
+        } else {
+            var iterator: io_iterator_t = 0
+            if IOServiceGetMatchingServices(kIOMasterPortDefault, IOServiceMatching("IODisplayConnect"), &iterator) == kIOReturnSuccess {
+                var service: io_object_t = 1
+                while service != 0 {
+                    service = IOIteratorNext(iterator)
+                    IODisplayGetFloatParameter(service, 0, kIODisplayBrightnessKey as CFString, &brightness)
+                    IOObjectRelease(service)
+                }
             }
         }
         return brightness

--- a/Pock/Private/Pock-Bridging-Header.h
+++ b/Pock/Private/Pock-Bridging-Header.h
@@ -12,3 +12,4 @@
 #import "./KeySenderHelper/KeySenderHelper.h"
 #import "./ISSoundAdditions/ISSoundAdditions.h"
 #import "./SystemHelper/SystemHelper.h"
+#import "./DKBrightness/CoreDisplayPrivateAPI.h"


### PR DESCRIPTION
Starting from 10.13, the IOKit API for changing display brighness does
not work as we expect. It initially changes the brighness, but then
reverts back to the previous setting after a certain amount of time.
See eg. here for more details: https://alexdelorenzo.dev/programming/2018/08/16/reverse_engineering_private_apple_apis.html

This fixes this by using the private CoreDisplay.framework API when
running on 10.13+.

fixes pigigaldi/Pock#353


**Pull request type**
Keep only the option that better matches your pull request.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

I tested this on
* Hardware: MacBook Pro, 13 (2019)
* macOS Version: 10.15.2
* Xcode version: 11.3.1


**Checklist**
Use this list to keep track of your progress:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
