### PR TITLE
Add Tidal icon support to now playing

### DIFF
--- a/Pock/Widgets/NowPlaying/NowPlayingItemView.swift
+++ b/Pock/Widgets/NowPlaying/NowPlayingItemView.swift
@@ -45,7 +45,7 @@ class NowPlayingItemView: PKDetailView {
         case "com.apple.WebKit.WebContent":
             appBundleIdentifier = "com.apple.Safari"
         case "com.spotify.client", "com.apple.iTunes", "com.apple.Safari", "com.google.Chrome", "com.netease.163music", "com.tencent.QQMusicMac",
-             "com.xiami.macclient", "com.apple.Music":
+             "com.xiami.macclient", "com.apple.Music", "com.tidal.desktop":
             break
         default:
             if #available(macOS 10.15, *) {


### PR DESCRIPTION
**Describe the Pull request**
This added Tidal icon support to the Now Playing widget.

**Screenshots**
I haven't setup Pock in development mode but my understanding of the code makes me confident in this. Here is the `Info.plist` for Tidal:
![image](https://user-images.githubusercontent.com/11750061/74746580-469d3280-522b-11ea-9694-7b4874cfe0ab.png)

**Fixes**
A comma-separated list of issues that can be closed with this PR.
Closes #213.

**Pull request type**
- [X] New feature (non-breaking change which adds functionality)

**Tested?**
Nope.

**Checklist**
Use this list to keep track of your progress:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works