### PR TITLE
Fix: Multiple Teams Issues (Badge, Crash, Icon, Jumping)

### DIFF
--- a/Pock/Private/PockDockHelper/PockDockHelper.h
+++ b/Pock/Private/PockDockHelper/PockDockHelper.h
@@ -25,6 +25,7 @@ extern AXError _AXUIElementGetWindow(AXUIElementRef window, CGWindowID *windowID
 
 + (PockDockHelper *)sharedInstance;
 - (NSString *)getBadgeCountForItemWithName:(NSString *)name;
+- (NSString *)getBadgeCountForItemWithPath:(NSURL *)path;
 - (NSArray *)getWindowsOfApp:(pid_t)pid;
 - (BOOL)windowIsFrontmost:(CGWindowID)wid forApp:(NSRunningApplication *)app;
 - (void)minimizeWindowItem:(CGWindowItem *)item;


### PR DESCRIPTION
---
This MR fixes multiple Teams issues that are caused by the Team Helper.
---

Teams has a dedicated App to show the notifications (called `Microsoft Teams Helper`).
It has the same bundleId, but a different name and bundleUrl.
This leads to some bugs (#20 #108 #158, #228, https://github.com/pigigaldi/Pock/issues/108#issuecomment-508012486)

I fixed these by also comparing apps by their bundleURL, but not only by their bundleId.

This seems to fix 4 Bugs:
- Wrong Teams Icon (see #20, #108, #158)
- Jumping Teams Icon (#108)\
_The reason was the start of the teams helper._
- Crashing Teams when clicked (#228)\
_The reason was the running of the teams helper._
- Missing badge (when the Helper is running) (https://github.com/pigigaldi/Pock/issues/108#issuecomment-508012486)

** Screenshot**
<img width="1004" alt="Touch Bar Bild 2020-05-21 um 11 59 08" src="https://user-images.githubusercontent.com/11719855/82547730-7d505500-9b5a-11ea-8c96-52196b16b9e0.png">


**Fixes**
#20, #108, #158, #228

**Testing**
*Test Configuration*:
* Hardware:           MacBook Pro, 16 (2019)
* macOS Version: 10.15.4
* Xcode version:   11.4.1 (11E503a)

1. Start Build
2. Open Teams
3. Get somebody to send you a message
4. See if Badge is still there and Icon is correct
5. Click on Teams Icon (while Teams Helper is running)
6. be satisfied 🎉

_You can check if the teams helper is running, via right-clicking on the dock icon of teams._

